### PR TITLE
Allow all cross-origin requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,12 @@ def before_request():
         comp_man.root_dir = app.config["COMPSTATE"]
     g.comp_man = comp_man
 
+@app.after_request
+def after_request(resp):
+    if 'Origin' in request.headers:
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+    return resp
+
 def match_json_info(comp, match):
     info = {
         "number": match.num,


### PR DESCRIPTION
Since the API is read-only anyway, this just simplifies the creation of clients that interface with the API since they won't need to proxy through a server.
