### PR TITLE
feat: Expose teams.rookie via teams endpoints

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -83,6 +83,7 @@ Get information about a team.
           "get": "...",
           "name": "..."
         },
+        "rookie": "...",
         "scores": {
             "game": "...",
             "league": "..."

--- a/sr/comp/http/server.py
+++ b/sr/comp/http/server.py
@@ -134,6 +134,7 @@ def team_info(comp: SRComp, team: Team) -> dict[str, Any]:
             'name': location,
             'get': url_for('get_location', name=location),
         },
+        'rookie': team.rookie,
         'scores': {
             'league': scores.league_points,
             'game': scores.game_points,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -297,6 +297,7 @@ class ApiTests(unittest.TestCase):
                 'get': '/locations/a-group',
                 'name': 'a-group',
             },
+            'rookie': False,
             'scores': {
                 'league': 68,
                 'game': 69,


### PR DESCRIPTION
This change adds an extra attribute to the `/teams` and `/teams/<TLA>` responses that contains whether a team is a rookie or not.

Exposing this via API will allow us to pull this info directly into the helpdesk system and offer additional assistance to rookie teams where required.

If possible, please could you deploy this change on the live compbox after it is merged?