### PR TITLE
Add support for knockout structure & brackets

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -4,3 +4,6 @@
 pip >= 20
 wheel >= 0.36
 setuptools >= 50
+
+# Temporarily include SRComp development branch
+git+https://github.com/PeterJCLaw/srcomp@knockout-brackets

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -4,6 +4,3 @@
 pip >= 20
 wheel >= 0.36
 setuptools >= 50
-
-# Temporarily include SRComp development branch
-git+https://github.com/PeterJCLaw/srcomp@knockout-brackets

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -266,6 +266,7 @@ limits start from the last match and work backwards.
             {
                 "arena": "...",
                 "display_name": "Match ...",
+                "knockout_bracket": "...",
                 "num": "...",
                 "scores": {
                     "game": {
@@ -326,6 +327,8 @@ Only one of the ``league`` or ``normalised`` sub-keys of ``scores`` will be
 present, though they contain the same data. ``league`` will be present for
 league matches while ``normalised`` will be present for knockout matches.
 
+``knockout_bracket`` is present only for knockout matches.
+
 Notably, teams which are disqualified or no-show from a match will have a
 normalised (league) score of zero but will still have a position value.
 
@@ -378,13 +381,32 @@ matches in this period.
 /knockout
 ---------
 
-Get a list of rounds which make up the knockouts. Each round is expressed
-as a list of matches which make up that round. Matches are expressed using
-the same format as the `/matches`_ endpoint.
+Get information about the knockouts. This comprises structural information
+(currently only a list of "brackets") and a list of "rounds" of matches.
+
+Brackets are typically used to express the logical structure of the matches in
+terms of the knockout, but have no bearing on the scheduling of the matches.
+This for example enables having an "Upper" and "Lower" bracket when running a
+double-elimination knockout. Brackets have a ``name`` and a ``display_name``.
+The former can be used to cross reference the ``knockout_bracket`` value on a
+match.
+
+Rounds are groups of matches which are scheduled as a block. Matches from
+different brackets *may* appear within the same round. Each round is expressed
+as a list of matches which make up that round. Matches are expressed using the
+same format as the `/matches`_ endpoint.
 
 .. code-block:: json
 
     {
+        "structure": {
+            "brackets": [
+                {
+                    "name": "...",
+                    "display_name": "..."
+                }
+            ]
+        },
         "rounds": [
             [
                 "...",
@@ -402,6 +424,18 @@ the same format as the `/matches`_ endpoint.
         ]
     }
 
+
+/knockout/structure
+-------------------
+
+Get structural information about the knockouts. This is equivalent to the
+``structure`` key in the ``/knockout`` endpoint.
+
+.. code-block:: json
+
+    {
+        "brackets": "..."
+    }
 
 /tiebreaker
 -----------

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -399,14 +399,6 @@ same format as the `/matches`_ endpoint.
 .. code-block:: json
 
     {
-        "structure": {
-            "brackets": [
-                {
-                    "name": "...",
-                    "display_name": "..."
-                }
-            ]
-        },
         "rounds": [
             [
                 "...",
@@ -421,7 +413,15 @@ same format as the `/matches`_ endpoint.
             [
                 "..."
             ]
-        ]
+        ],
+        "structure": {
+            "brackets": [
+                {
+                    "name": "...",
+                    "display_name": "..."
+                }
+            ]
+        }
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     author="Student Robotics Competition Software SIG",
     author_email="srobo-devel@googlegroups.com",
     install_requires=[
-        # TODO(PR): bump srcomp version once we know what version will include knockout-brackets # noqa: E501
-        'sr.comp >=1.5, <2',
+        # 1.14 adds support for knockout structure info
+        'sr.comp >=1.14, <2',
         'Flask >=2.2',
         'Werkzeug >= 2, <4',
         'simplejson >=3.6, <4',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author="Student Robotics Competition Software SIG",
     author_email="srobo-devel@googlegroups.com",
     install_requires=[
+        # TODO(PR): bump srcomp version once we know what version will include knockout-brackets # noqa: E501
         'sr.comp >=1.5, <2',
         'Flask >=2.2',
         'Werkzeug >= 2, <4',

--- a/sr/comp/http/query_utils.py
+++ b/sr/comp/http/query_utils.py
@@ -10,7 +10,7 @@ from typing_extensions import NotRequired, TypedDict
 from league_ranker import LeaguePoints, RankedPosition
 
 from sr.comp.comp import SRComp
-from sr.comp.match_period import Match, MatchType
+from sr.comp.match_period import KnockoutMatch, Match, MatchType
 from sr.comp.types import ArenaName, GamePoints, MatchNumber, ShepherdName, TLA
 
 
@@ -135,12 +135,9 @@ def match_json_info(comp: SRComp, match: Match) -> MatchInfo | KnockoutMatchInfo
             }
 
     if match.type == MatchType.knockout:
+        assert isinstance(match, KnockoutMatch)
         info = KnockoutMatchInfo({
-            'knockout_bracket': (
-                'lower-bracket'
-                if match.display_name.startswith("Lower")
-                else 'upper-bracket'
-            ),
+            'knockout_bracket': match.knockout_bracket,
             **info,
         })
 

--- a/sr/comp/http/query_utils.py
+++ b/sr/comp/http/query_utils.py
@@ -58,10 +58,14 @@ class MatchInfo(TypedDict):
     scores: NotRequired[MatchScoreDict]
 
 
+class KnockoutMatchInfo(MatchInfo):
+    knockout_bracket: str
+
+
 TParseable = TypeVar('TParseable', int, str, datetime.datetime)
 
 
-def match_json_info(comp: SRComp, match: Match) -> MatchInfo:
+def match_json_info(comp: SRComp, match: Match) -> MatchInfo | KnockoutMatchInfo:
     """
     Get match JSON information.
 
@@ -129,6 +133,16 @@ def match_json_info(comp: SRComp, match: Match) -> MatchInfo:
                 'normalised': score_info.normalised,
                 'ranking': score_info.ranking,
             }
+
+    if match.type == MatchType.knockout:
+        info = KnockoutMatchInfo({
+            'knockout_bracket': (
+                'lower-bracket'
+                if match.display_name.startswith("Lower")
+                else 'upper-bracket'
+            ),
+            **info,
+        })
 
     return info
 

--- a/sr/comp/http/server.py
+++ b/sr/comp/http/server.py
@@ -418,40 +418,31 @@ def current_state() -> Response:
     )
 
 
+def _knockout_structure(comp: SRComp) -> dict[str, Any]:
+    return {
+        'brackets': [
+            {
+                'name': x.name,
+                'display_name': x.display_name,
+            }
+            for x in comp.schedule.knockout_brackets
+        ],
+    }
+
+
 @app.route('/knockout')
 def knockout() -> Response:
     comp: SRComp = g.comp_man.get_comp()
     return jsonify(
         rounds=comp.schedule.knockout_rounds,
-        structure={
-            'brackets': [
-                {
-                    'name': 'upper-bracket',
-                    'display_name': "Upper Bracket",
-                },
-                {
-                    'name': 'lower-bracket',
-                    'display_name': "Lower Bracket",
-                },
-            ],
-        },
+        structure=_knockout_structure(comp),
     )
 
 
 @app.route('/knockout/structure')
 def knockout_structure() -> Response:
-    return jsonify({
-        'brackets': [
-            {
-                'name': 'upper-bracket',
-                'display_name': "Upper Bracket",
-            },
-            {
-                'name': 'lower-bracket',
-                'display_name': "Lower Bracket",
-            },
-        ],
-    })
+    comp: SRComp = g.comp_man.get_comp()
+    return jsonify(_knockout_structure(comp))
 
 
 @app.route('/tiebreaker')

--- a/sr/comp/http/server.py
+++ b/sr/comp/http/server.py
@@ -421,7 +421,37 @@ def current_state() -> Response:
 @app.route('/knockout')
 def knockout() -> Response:
     comp: SRComp = g.comp_man.get_comp()
-    return jsonify(rounds=comp.schedule.knockout_rounds)
+    return jsonify(
+        rounds=comp.schedule.knockout_rounds,
+        structure={
+            'brackets': [
+                {
+                    'name': 'upper-bracket',
+                    'display_name': "Upper Bracket",
+                },
+                {
+                    'name': 'lower-bracket',
+                    'display_name': "Lower Bracket",
+                },
+            ],
+        },
+    )
+
+
+@app.route('/knockout/structure')
+def knockout_structure() -> Response:
+    return jsonify({
+        'brackets': [
+            {
+                'name': 'upper-bracket',
+                'display_name': "Upper Bracket",
+            },
+            {
+                'name': 'lower-bracket',
+                'display_name': "Lower Bracket",
+            },
+        ],
+    })
 
 
 @app.route('/tiebreaker')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,6 +414,7 @@ class ApiTests(unittest.TestCase):
                 {
                     'display_name': 'Final (#129)',
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                     'num': 129,
                     'arena': 'A',
                     'times': {
@@ -451,6 +452,7 @@ class ApiTests(unittest.TestCase):
                 {
                     'display_name': 'Final (#129)',
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                     'num': 129,
                     'arena': 'A',
                     'times': {
@@ -496,6 +498,7 @@ class ApiTests(unittest.TestCase):
                 {
                     'display_name': 'Final (#129)',
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                     'num': 129,
                     'arena': 'A',
                     'times': {
@@ -663,6 +666,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -671,6 +675,7 @@ class ApiTests(unittest.TestCase):
                     'teams': [None, '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -679,6 +684,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -687,6 +693,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', None],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -695,6 +702,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -703,6 +711,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', None],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -711,6 +720,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', None, '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -719,6 +729,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', None, '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -727,6 +738,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', None, '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -735,6 +747,7 @@ class ApiTests(unittest.TestCase):
                     'teams': [None, '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -743,6 +756,7 @@ class ApiTests(unittest.TestCase):
                     'teams': [None, '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -751,6 +765,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -759,6 +774,7 @@ class ApiTests(unittest.TestCase):
                     'teams': [None, '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -767,6 +783,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', None],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -775,6 +792,7 @@ class ApiTests(unittest.TestCase):
                     'teams': [None, '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -783,6 +801,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
             ],
             [
@@ -793,6 +812,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -801,6 +821,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -809,6 +830,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -817,6 +839,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -825,6 +848,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -833,6 +857,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -841,6 +866,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'B',
@@ -849,6 +875,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
             ],
             [
@@ -859,6 +886,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -867,6 +895,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -875,6 +904,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -883,6 +913,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
             ],
             [
@@ -893,6 +924,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
                 {
                     'arena': 'A',
@@ -901,6 +933,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
             ],
             [
@@ -911,6 +944,7 @@ class ApiTests(unittest.TestCase):
                     'teams': ['???', '???', '???', '???'],
                     'times': None,
                     'type': 'knockout',
+                    'knockout_bracket': 'default',
                 },
             ],
         ]
@@ -951,6 +985,20 @@ class ApiTests(unittest.TestCase):
 
         # Just in case the above is faulty
         self.assertEqual(ref, actual_rounds)
+
+    def test_knockout_structure_key(self) -> None:
+        actual_structure = self.server_get('knockout')['structure']
+        self.assertEqual(
+            {'brackets': [{'name': 'default', 'display_name': "Knockouts"}]},
+            actual_structure,
+        )
+
+    def test_knockout_structure_endpoint(self) -> None:
+        actual_structure = self.server_get('/knockout/structure')
+        self.assertEqual(
+            {'brackets': [{'name': 'default', 'display_name': "Knockouts"}]},
+            actual_structure,
+        )
 
     def test_tiebreaker(self) -> None:
         with self.assertRaisesApiError('NotFound', 404):


### PR DESCRIPTION
Knockout brackets are (at this point) a purely display related concern to enable splitting the diagram shown on the screens into more manageable chunks. The expectation is that they will be used for e.g: a double elimination style knockout where there's an "Upper" and "Lower" bracket, but the mapping from match to bracket is arbitrary.

This PR exposes the brackets from the core library into the HTTP API.

Depends on https://github.com/PeterJCLaw/srcomp/pull/56